### PR TITLE
Regularized model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,8 @@ DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
 ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"
 QuadraticModels = "f468eda6-eac5-11e8-05a5-ff9e497bcd19"
+ShiftedProximalOperators = "d4fd37fa-580c-4e43-9b30-361c21aae263"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADNLPModels", "DifferentialEquations", "MLDatasets", "ProximalOperators", "QuadraticModels", "Test"]
+test = ["ADNLPModels", "DifferentialEquations", "MLDatasets", "ProximalOperators", "QuadraticModels", "ShiftedProximalOperators", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,14 +19,15 @@ MLDatasets = "^0.7.4"
 NLPModels = "0.16, 0.17, 0.18, 0.19, 0.20"
 Noise = "0.2"
 Requires = "1"
-julia = "^1.3.0"
+julia = "^1.6.0"
 
 [extras]
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
+ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"
 QuadraticModels = "f468eda6-eac5-11e8-05a5-ff9e497bcd19"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADNLPModels", "DifferentialEquations", "MLDatasets", "QuadraticModels", "Test"]
+test = ["ADNLPModels", "DifferentialEquations", "MLDatasets", "ProximalOperators", "QuadraticModels", "Test"]

--- a/src/RegularizedProblems.jl
+++ b/src/RegularizedProblems.jl
@@ -18,15 +18,26 @@ function __init__()
     include("testset_bpdn.jl")
     include("testset_lrcomp.jl")
     include("testset_matrand.jl")
+    include("testset_nnmf.jl")
+  end
+  @require ShiftedProximalOperators = "d4fd37fa-580c-4e43-9b30-361c21aae263" begin
     include("testset_group_lasso.jl")
   end
   @require ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a" begin
     @require DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa" begin
       include("fh_model.jl")
+      @require ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537" begin
+        include("testset_fh.jl")
+      end
     end
   end
   @require MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458" begin
     include("nonlin_svm_model.jl")
+    @require ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537" begin
+      @require ShiftedProximalOperators = "d4fd37fa-580c-4e43-9b30-361c21aae263" begin
+        include("testset_svm.jl")
+      end
+    end
   end
   @require QuadraticModels = "f468eda6-eac5-11e8-05a5-ff9e497bcd19" begin
     include("qp_rand_model.jl")

--- a/src/RegularizedProblems.jl
+++ b/src/RegularizedProblems.jl
@@ -14,6 +14,12 @@ include("group_lasso_model.jl")
 include("nnmf.jl")
 
 function __init__()
+  @require ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537" begin
+    include("testset_bpdn.jl")
+    include("testset_lrcomp.jl")
+    include("testset_matrand.jl")
+    include("testset_group_lasso.jl")
+  end
   @require ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a" begin
     @require DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa" begin
       include("fh_model.jl")

--- a/src/bpdn_model.jl
+++ b/src/bpdn_model.jl
@@ -21,8 +21,8 @@ bpdn_data(compound::Int = 1, args...; bounds::Bool = false) =
   bpdn_data(200 * compound, 512 * compound, 10 * compound, args...; bounds = bounds)
 
 """
-    model, nls_model, sol = bpdn_model(args...)
-    model, nls_model, sol = bpdn_model(compound = 1, args...)
+    model, nls_model, sol = bpdn_model(args...; kwargs...)
+    model, nls_model, sol = bpdn_model(compound = 1, args...; kwargs...)
 
 Return an instance of an `NLPModel` and an instance of an `NLSModel` representing
 the same basis-pursuit denoise problem, i.e., the under-determined linear

--- a/src/lrcomp_model.jl
+++ b/src/lrcomp_model.jl
@@ -5,7 +5,7 @@ function lrcomp_data(m::Int, n::Int; T::DataType = Float64)
   A
 end
 
-function lrcomp_model(m::Int, n::Int; T::DataType = Float64)
+function lrcomp_model(; m::Int = 100, n::Int = 100, T::DataType = Float64)
   A = lrcomp_data(m, n, T = T)
   r = vec(similar(A))
 

--- a/src/matrand_model.jl
+++ b/src/matrand_model.jl
@@ -7,7 +7,7 @@ function mat_rand(m::Int, n::Int, r::Int, sr::Float64, va::Float64, vb::Float64,
   Ω = findall(<(sr), rand(m, n))
   B = xs[Ω]
   B = (1 - c) * add_gauss(B, va, 0; clip = true) + c * add_gauss(B, vb, 0; clip = true)
-  ω = zeros(Int64, size(Ω, 1))   # Vectorize Omega 
+  ω = zeros(Int64, size(Ω, 1))   # Vectorize Omega
   for i = 1:size(Ω, 1)
     ω[i] = Ω[i][1] + size(Ω, 2) * (Ω[i][2] - 1)
   end
@@ -44,7 +44,7 @@ function matrix_completion_model(xs, B, ω)
 end
 
 """
-    model, nls_model, sol = random_matrix_completion_model(args...)
+    model, nls_model, sol = random_matrix_completion_model(; kwargs...)
 
 Return an instance of an `NLPModel` and an instance of an `NLSModel` representing
 the same matrix completion problem, i.e., the square linear least-squares objective
@@ -55,38 +55,38 @@ in the Frobenius norm, where X is the unknown image represented as an m x n matr
 A is a fixed image, and the operator P only retains a certain subset of pixels of
 X and A.
 
-## Arguments
+## Keyword Arguments
 
-* `m :: Int`: the number of rows of X and A
-* `n :: Int`: the number of columns of X and A
-* `r :: Int`: the desired rank of A
+* `m :: Int`: the number of rows of X and A (default: 100)
+* `n :: Int`: the number of columns of X and A (default: 100)
+* `r :: Int`: the desired rank of A (default: 5)
 * `sr :: AbstractFloat`: a threshold between 0 and 1 used to determine the set of pixels
-  retained by the operator P
-* `va :: AbstractFloat`: the variance of a first Gaussian perturbation to be applied to A
-* `vb :: AbstractFloat`: the variance of a second Gaussian perturbation to be applied to A
-* `c :: AbstractFloat`: the coefficient of the convex combination of the two Gaussian perturbations.
+retained by the operator P (default: 0.8)
+* `va :: AbstractFloat`: the variance of a first Gaussian perturbation to be applied to A (default: 1.0e-4)
+* `vb :: AbstractFloat`: the variance of a second Gaussian perturbation to be applied to A (default: 1.0e-2)
+* `c :: AbstractFloat`: the coefficient of the convex combination of the two Gaussian perturbations (default: 0.2).
 
 ## Return Value
 
 An instance of a `FirstOrderModel` and of a `FirstOrderNLSModel` that represent the same
 matrix completion problem, and the exact solution.
 """
-function random_matrix_completion_model(
-  m::Int,
-  n::Int,
-  r::Int,
-  sr::R,
-  va::R,
-  vb::R,
-  c::R,
-) where {R <: AbstractFloat}
+function random_matrix_completion_model(;
+  m::Int = 100,
+  n::Int = 100,
+  r::Int = 5,
+  sr::Float64 = 0.8,
+  va::Float64 = 1.0e-4,
+  vb::Float64 = 1.0e-2,
+  c::Float64 = 0.2,
+)
   xs, B, ω = mat_rand(m, n, r, sr, va, vb, c)
   matrix_completion_model(xs, B, ω)
 end
 
 function perturb(I, c = 0.8, p = 0.8)
   Ω = findall(<(p), rand(256, 256))
-  ω = zeros(Int, size(Ω, 1))   # Vectorize Omega 
+  ω = zeros(Int, size(Ω, 1))   # Vectorize Omega
   for i = 1:size(Ω, 1)
     ω[i] = Ω[i][1] + 256 * (Ω[i][2] - 1)
   end
@@ -98,7 +98,7 @@ function perturb(I, c = 0.8, p = 0.8)
 end
 
 """
-    model, nls_model, sol = MIT_matrix_completion_model(args...)
+    model, nls_model, sol = MIT_matrix_completion_model()
 
 A special case of matrix completion problem in which the exact image is a noisy
 MIT logo.

--- a/src/qp_rand_model.jl
+++ b/src/qp_rand_model.jl
@@ -2,17 +2,17 @@ export qp_rand_model
 using .QuadraticModels
 
 """
-    model = qp_rand_model(n; dens = 1.0e-4, convex = false)
+    model = qp_rand_model(n = 100_000; dens = 1.0e-4, convex = false)
 
 Return an instance of a `QuadraticModel` representing
 
    min cᵀx + ½ xᵀHx   s.t.  l ≤ x ≤ u,
 
-with H = A + A' or H = A * A' (see the `convex` keyword argument) where A is a random square matrix with density `dens`, `l = -e - tₗ` and `u = e + tᵤ` where `e` is the vector of ones, and `tₗ` and `tᵤ` are sampled from a uniform distribution between 0 and 1.    
+with H = A + A' or H = A * A' (see the `convex` keyword argument) where A is a random square matrix with density `dens`, `l = -e - tₗ` and `u = e + tᵤ` where `e` is the vector of ones, and `tₗ` and `tᵤ` are sampled from a uniform distribution between 0 and 1.
 
 ## Arguments
 
-* `n :: Int`: size of the problem,
+* `n :: Int`: size of the problem (default: `100_000`).
 
 ## Keyword arguments
 
@@ -23,7 +23,7 @@ with H = A + A' or H = A * A' (see the `convex` keyword argument) where A is a r
 
 An instance of a `QuadraticModel`.
 """
-function qp_rand_model(n::Int; dens::R = 1.0e-4, convex::Bool = false) where {R <: Real}
+function qp_rand_model(n::Int = 100_000; dens::R = 1.0e-4, convex::Bool = false) where {R <: Real}
   @assert 0 < dens ≤ 1
   A = sprandn(R, n, n, dens)
   H = convex ? (A * A') : (A + A')

--- a/src/testset_bpdn.jl
+++ b/src/testset_bpdn.jl
@@ -1,0 +1,22 @@
+# Predefine a set of common problem instances.
+export setup_bpdn_l0, setup_bpdn_l1, setup_bpdn_B0
+
+function setup_bpdn_l0(args...; kwargs...)
+  model, nls_model, _ = bpdn_model(args...)
+  λ = norm(grad(model, zeros(model.meta.nvar)), Inf) / 10
+  h = NormL0(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_bpdn_l1(args...; kwargs...)
+  model, nls_model, _ = bpdn_model(args...)
+  λ = norm(grad(model, zeros(model.meta.nvar)), Inf) / 10
+  h = NormL1(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_bpdn_B0(compound = 1, args...; kwargs...)
+  model, nls_model, _ = bpdn_model(compound, args...)
+  h = IndBallL0(10 * compound)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end

--- a/src/testset_bpdn.jl
+++ b/src/testset_bpdn.jl
@@ -2,21 +2,21 @@
 export setup_bpdn_l0, setup_bpdn_l1, setup_bpdn_B0
 
 function setup_bpdn_l0(args...; kwargs...)
-  model, nls_model, _ = bpdn_model(args...)
+  model, nls_model, _ = bpdn_model(args...; kwargs...)
   λ = norm(grad(model, zeros(model.meta.nvar)), Inf) / 10
-  h = NormL0(λ)
+  h = ProximalOperators.NormL0(λ)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end
 
 function setup_bpdn_l1(args...; kwargs...)
-  model, nls_model, _ = bpdn_model(args...)
+  model, nls_model, _ = bpdn_model(args...; kwargs...)
   λ = norm(grad(model, zeros(model.meta.nvar)), Inf) / 10
-  h = NormL1(λ)
+  h = ProximalOperators.NormL1(λ)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end
 
 function setup_bpdn_B0(compound = 1, args...; kwargs...)
-  model, nls_model, _ = bpdn_model(compound, args...)
-  h = IndBallL0(10 * compound)
+  model, nls_model, _ = bpdn_model(compound, args...; kwargs...)
+  h = ProximalOperators.IndBallL0(10 * compound)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end

--- a/src/testset_fh.jl
+++ b/src/testset_fh.jl
@@ -1,0 +1,14 @@
+# Predefine a set of common problem instances.
+export setup_fh_l0, setup_fh_l1
+
+function setup_fh_l0(; kwargs...)
+  model, nls_model, _ = fh_model(; kwargs...)
+  h = ProximalOperators.NormL0(1.0)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_fh_l1(; kwargs...)
+  model, nls_model, _ = fh_model(; kwargs...)
+  h = ProximalOperators.NormL1(10.0)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end

--- a/src/testset_group_lasso.jl
+++ b/src/testset_group_lasso.jl
@@ -1,0 +1,11 @@
+# Predefine a set of common problem instances.
+export setup_group_lasso_l12
+
+function setup_group_lasso_l12(args...; kwargs...)
+  model, nls_model, ng, _, idx = group_lasso_model(; kwargs...)
+  idx = [idx[i, :] for i = 1:ng]
+  λ = 0.2 * ones(ng)
+  h = GroupNormL2(λ, idx)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+

--- a/src/testset_group_lasso.jl
+++ b/src/testset_group_lasso.jl
@@ -5,7 +5,6 @@ function setup_group_lasso_l12(args...; kwargs...)
   model, nls_model, ng, _, idx = group_lasso_model(; kwargs...)
   idx = [idx[i, :] for i = 1:ng]
   λ = 0.2 * ones(ng)
-  h = GroupNormL2(λ, idx)
+  h = ShiftedProximalOperators.GroupNormL2(λ, idx)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end
-

--- a/src/testset_lrcomp.jl
+++ b/src/testset_lrcomp.jl
@@ -1,0 +1,16 @@
+# Predefine a set of common problem instances.
+export setup_lrcomp_rank, setup_lrcomp_nuclear
+
+function setup_lrcomp_rank(args...; kwargs...)
+  model, nls_model, _ = lrcomp_model(args...; kwargs...)
+  λ = 0.1
+  h = Rank(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_lrcomp_nuclear(args...; kwargs...)
+  model, nls_model, _ = lrcomp_model(args...; kwargs...)
+  λ = 0.1
+  h = NuclearNorm(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end

--- a/src/testset_lrcomp.jl
+++ b/src/testset_lrcomp.jl
@@ -2,15 +2,15 @@
 export setup_lrcomp_rank, setup_lrcomp_nuclear
 
 function setup_lrcomp_rank(args...; kwargs...)
-  model, nls_model, _ = lrcomp_model(args...; kwargs...)
+  model, nls_model, _ = lrcomp_model(; kwargs...)
   λ = 0.1
-  h = Rank(λ)
+  h = ProximalOperators.Rank(λ)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end
 
 function setup_lrcomp_nuclear(args...; kwargs...)
-  model, nls_model, _ = lrcomp_model(args...; kwargs...)
+  model, nls_model, _ = lrcomp_model(; kwargs...)
   λ = 0.1
-  h = NuclearNorm(λ)
+  h = ProximalOperators.NuclearNorm(λ)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end

--- a/src/testset_matrand.jl
+++ b/src/testset_matrand.jl
@@ -1,0 +1,31 @@
+# Predefine a set of common problem instances.
+export setup_random_completion_rank, setup_random_completion_nuclear
+export setup_mit_completion_rank, setup_mit_completion_nuclear
+
+function setup_random_completion_rank(args...; kwargs...)
+  model, nls_model, _ = random_matrix_completion_model(; kwargs...)
+  λ = 0.1
+  h = Rank(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_random_completion_nuclear(args...; kwargs...)
+  model, nls_model, _ = random_matrix_completion_model(; kwargs...)
+  λ = 0.1
+  h = NuclearNorm(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_mit_completion_rank(args...; kwargs...)
+  model, nls_model, _ = MIT_matrix_completion_model()
+  λ = 0.1
+  h = Rank(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_mit_completion_nuclear(args...; kwargs...)
+  model, nls_model, _ = MIT_matrix_completion_model()
+  λ = 0.1
+  h = NuclearNorm(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end

--- a/src/testset_matrand.jl
+++ b/src/testset_matrand.jl
@@ -5,27 +5,27 @@ export setup_mit_completion_rank, setup_mit_completion_nuclear
 function setup_random_completion_rank(args...; kwargs...)
   model, nls_model, _ = random_matrix_completion_model(; kwargs...)
   λ = 0.1
-  h = Rank(λ)
+  h = ProximalOperators.Rank(λ)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end
 
 function setup_random_completion_nuclear(args...; kwargs...)
   model, nls_model, _ = random_matrix_completion_model(; kwargs...)
   λ = 0.1
-  h = NuclearNorm(λ)
+  h = ProximalOperators.NuclearNorm(λ)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end
 
 function setup_mit_completion_rank(args...; kwargs...)
   model, nls_model, _ = MIT_matrix_completion_model()
   λ = 0.1
-  h = Rank(λ)
+  h = ProximalOperators.Rank(λ)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end
 
 function setup_mit_completion_nuclear(args...; kwargs...)
   model, nls_model, _ = MIT_matrix_completion_model()
   λ = 0.1
-  h = NuclearNorm(λ)
+  h = ProximalOperators.NuclearNorm(λ)
   return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
 end

--- a/src/testset_nnmf.jl
+++ b/src/testset_nnmf.jl
@@ -1,0 +1,16 @@
+# Predefine a set of common problem instances.
+export setup_nnmf_l0, setup_nnmf_l1
+
+function setup_nnmf_l0(args...; kwargs...)
+  model, nls_model, _, selected = nnmf_model(args...)
+  λ = norm(grad(model, rand(model.meta.nvar)), Inf) / 200
+  h = ProximalOperators.NormL0(λ)
+  return RegularizedNLPModel(model, h, selected), RegularizedNLSModel(nls_model, h, selected)
+end
+
+function setup_nnmf_l1(args...; kwargs...)
+  model, nls_model, _, selected = nnmf_model(args...)
+  λ = norm(grad(model, rand(model.meta.nvar)), Inf) / 100_000
+  h = ProximalOperators.NormL1(λ)
+  return RegularizedNLPModel(model, h, selected), RegularizedNLSModel(nls_model, h, selected)
+end

--- a/src/testset_qp_rand.jl
+++ b/src/testset_qp_rand.jl
@@ -1,0 +1,9 @@
+# Predefine a set of common problem instances.
+export setup_qp_rand_l1
+
+function setup_qp_rand_l1(args...; kwargs...)
+  model, nls_model, _ = qp_rand_model(args...; kwargs...)
+  λ = 0.1
+  h = ProximalOperators.NormL1(λ)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end

--- a/src/testset_svm.jl
+++ b/src/testset_svm.jl
@@ -1,0 +1,39 @@
+# Predefine a set of common problem instances.
+export setup_svm_train_lhalf,
+  setup_svm_test_lhalf, setup_svm_train_l0, setup_svm_test_l0, setup_svm_train_l1, setup_svm_test_l1
+
+function setup_svm_train_lhalf(args...; kwargs...)
+  model, nls_model, _ = svm_train_model(args...)
+  h = ShiftedProximalOperators.RootNormLhalf(0.1)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_svm_test_lhalf(args...; kwargs...)
+  model, nls_model, _ = svm_test_model(args...)
+  h = ShiftedProximalOperators.RootNormLhalf(0.1)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_svm_train_l0(args...; kwargs...)
+  model, nls_model, _ = svm_train_model(args...)
+  h = ProximalOperators.NormL0(0.1)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_svm_test_l0(args...; kwargs...)
+  model, nls_model, _ = svm_test_model(args...)
+  h = ProximalOperators.NormL0(0.1)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_svm_train_l1(args...; kwargs...)
+  model, nls_model, _ = svm_train_model(args...)
+  h = ProximalOperators.NormL1(0.1)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end
+
+function setup_svm_test_l1(args...; kwargs...)
+  model, nls_model, _ = svm_test_model(args...)
+  h = ProximalOperators.NormL1(0.1)
+  return RegularizedNLPModel(model, h), RegularizedNLSModel(nls_model, h)
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,5 @@
-export FirstOrderModel, FirstOrderNLSModel
+export FirstOrderModel,
+  FirstOrderNLSModel, AbstractRegularizedNLPModel, RegularizedNLPModel, RegularizedNLSModel
 
 """
     model = FirstOrderModel(f, ∇f!; name = "first-order model")
@@ -130,4 +131,99 @@ function NLPModels.jtprod_residual!(
   increment!(nls, :neval_jtprod_residual)
   nls.jtprod_resid!(Jtv, x, v)
   Jtv
+end
+
+abstract type AbstractRegularizedNLPModel{T, S} <: AbstractNLPModel{T, S} end
+
+"""
+    rmodel = RegularizedNLPModel(model, regularizer)
+    rmodel = RegularizedNLSModel(model, regularizer)
+
+An aggregate type to represent a regularized optimization model, .i.e.,
+of the form
+
+    minimize f(x) + h(x),
+
+where f is smooth (and is usually assumed to have Lipschitz-continuous gradient),
+and h is lower semi-continuous (and may have to be prox-bounded).
+
+The regularized model is made of
+
+- `model <: AbstractNLPModel`: the smooth part of the model, for example a `FirstOrderModel`
+- `h`: the nonsmooth part of the model; typically a regularizer defined in `ProximalOperators.jl`
+- `selected`: the subset of variables to which the regularizer h should be applied (default: all).
+
+This aggregate type can be used to call solvers with a single object representing the
+model, but is especially useful for use with SolverBenchmark.jl, which expects problems
+to be defined by a single object.
+"""
+mutable struct RegularizedNLPModel{T, S, M <: AbstractNLPModel{T, S}, H, I} <:
+               AbstractRegularizedNLPModel{T, S}
+  model::M     # smooth  model
+  h::H         # regularizer
+  selected::I  # set of variables to which the regularizer should be applied
+end
+
+function RegularizedNLPModel(model::AbstractNLPModel{T, S}, h::H) where {T, S, H}
+  selected = 1:get_nvar(model)
+  RegularizedNLPModel{T, S, typeof(model), typeof(h), typeof(selected)}(model, h, selected)
+end
+
+mutable struct RegularizedNLSModel{T, S, M <: AbstractNLSModel{T, S}, H, I} <:
+               AbstractRegularizedNLPModel{T, S}
+  model::M     # smooth  model
+  h::H         # regularizer
+  selected::I  # set of variables to which the regularizer should be applied
+end
+
+function RegularizedNLSModel(model::AbstractNLSModel{T, S}, h::H) where {T, S, H}
+  selected = 1:get_nvar(model)
+  RegularizedNLSModel{T, S, typeof(model), typeof(h), typeof(selected)}(model, h, selected)
+end
+
+function NLPModels.obj(rnlp::AbstractRegularizedNLPModel, x::AbstractVector)
+  # The size check on x will be performed when evaluating the smooth model.
+  # We intentionally do not increment an objective evaluation counter here
+  # because the relevant counters are inside the smooth term.
+  obj(rnlp.model, x) + rnlp.h(x)
+end
+
+# Forward meta getters so they grab info from the smooth model
+for field ∈ fieldnames(NLPModels.NLPModelMeta)
+  meth = Symbol("get_", field)
+  if field == :name
+    @eval NLPModels.$meth(rnlp::RegularizedNLPModel) =
+      NLPModels.$meth(rnlp.model) * "/" * string(typeof(rnlp.h).name.wrapper)
+    @eval NLPModels.$meth(rnls::RegularizedNLSModel) =
+      NLPModels.$meth(rnls.model) * "/" * string(typeof(rnls.h).name.wrapper)
+  else
+    @eval NLPModels.$meth(rnlp::RegularizedNLPModel) = NLPModels.$meth(rnlp.model)
+  end
+end
+
+for field in fieldnames(NLPModels.NLSMeta)
+  meth = Symbol("get_", field)
+  @eval NLPModels.$meth(rnls::RegularizedNLSModel) = NLPModels.$meth(rnls.model)
+end
+
+# Forward counter getters so they grab info from the smooth model
+for model_type ∈ (RegularizedNLPModel, RegularizedNLSModel)
+  for counter in fieldnames(Counters)
+    @eval NLPModels.$counter(rnlp::$model_type) = NLPModels.$counter(rnlp.model)
+  end
+end
+
+for counter in fieldnames(NLSCounters)
+  counter == :counters && continue
+  @eval NLPModels.$counter(rnls::RegularizedNLSModel) = NLPModels.$counter(rnls.model)
+end
+
+# simple show method for now
+function Base.show(io::IO, rnlp::AbstractRegularizedNLPModel)
+  print(io, "Smooth model: ")
+  show(io, rnlp.model)
+  print(io, "\nRegularizer: ")
+  show(io, rnlp.h)
+  print(io, "\n\nSelected variables: ")
+  show(io, rnlp.selected)
 end

--- a/test/rmodel_tests.jl
+++ b/test/rmodel_tests.jl
@@ -1,0 +1,18 @@
+using ProximalOperators
+
+@testset "RegularizedNLPModel" begin
+  model, nls_model, x0 = bpdn_model(1)
+  h = NormL0(1.0)
+  rmodel = RegularizedNLPModel(model, h)
+  bpdn_name = get_name(model)
+  @test get_name(rmodel) == bpdn_name * "/NormL0"
+  @test get_nvar(rmodel) == get_nvar(model)
+  obj(model, model.meta.x0)
+  @test neval_obj(rmodel) == neval_obj(model)
+  rlsmodel = RegularizedNLSModel(nls_model, h)
+  bpdn_ls_name = get_name(nls_model)
+  @test get_name(rlsmodel) == bpdn_ls_name * "/NormL0"
+  @test get_nequ(rlsmodel) == get_nequ(nls_model)
+  obj(nls_model, nls_model.meta.x0)
+  @test neval_obj(rlsmodel) == neval_obj(nls_model)
+end

--- a/test/rmodel_tests.jl
+++ b/test/rmodel_tests.jl
@@ -16,3 +16,10 @@ using ProximalOperators
   obj(nls_model, nls_model.meta.x0)
   @test neval_obj(rlsmodel) == neval_obj(nls_model)
 end
+
+@testset "Problem combos" begin
+  # Test that we can at least instantiate the models
+  rnlp, rnls = setup_bpdn_l0()
+  @test isa(rnlp, RegularizedNLPModel)
+  @test isa(rnls, RegularizedNLSModel)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,7 +74,7 @@ end
 end
 
 @testset "low-rank completion" begin
-  model, nls_model, A = lrcomp_model(100, 100)
+  model, nls_model, A = lrcomp_model()
   test_well_defined(model, nls_model, A)
   test_objectives(model, nls_model)
   @test model.meta.nvar == 10000
@@ -84,7 +84,7 @@ end
 end
 
 @testset "mat_rand" begin
-  model, nls_model, sol = random_matrix_completion_model(100, 100, 5, 0.8, 0.0001, 0.01, 0.2)
+  model, nls_model, sol = random_matrix_completion_model()
   test_well_defined(model, nls_model, sol)
   test_objectives(model, nls_model)
   @test model.meta.nvar == 10000
@@ -164,3 +164,5 @@ end
   @test all(0.0 .≤ model.meta.uvar .≤ 2.0)
   @test all(model.meta.x0 .== 0)
 end
+
+include("rmodel_tests.jl")


### PR DESCRIPTION
This PR introduces the new types `RegularizedNLPModel` and `RegularizedNLSModel`. Both combine a smooth model with a nonsmooth regularizer into a single type. Usual `NLPModel` methods are defined for those types. The end objective is that running benchmarks with SolverBenchmarks will require problems to be specified as a single object (not f and h separately).

In addition, I add many `setup_…()` methods that predefine common problem combos (BPDN/ℓ0, FH/ℓ1, etc.). That should make it easier to run tests and benchmarks down the line. I had to slightly rework the interface of a few problems so they can be instantiated with default parameters when no input arguments are passed in. More precisely, you can call `setup_bpdn_l0()` with no arguments to get a problem of default size, but you can also pass in arguments accepted by `bpdn_model()` to change the size.

@rjbaraldi @MohamedLaghdafHABIBOULLAH @geoffroyleconte What do you think?
