### PR TITLE
Change compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Dominique Orban <dominique.orban@gmail.com>, Robert Baraldi <robertj
 version = "0.1.1"
 
 [deps]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
@@ -13,7 +14,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-ADNLPModels = "^0.3, 0.4, 0.7"
+ADNLPModels = "0.3, 0.4, 0.7"
 Distributions = "0.25"
 MLDatasets = "^0.7.4"
 NLPModels = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
@@ -22,7 +23,6 @@ Requires = "1"
 julia = "^1.6.0"
 
 [extras]
-ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
 ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"

--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ Requires = "1"
 julia = "^1.6.0"
 
 [extras]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
 ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"


### PR DESCRIPTION
Version >0.7 in ADNLPModels uses tracers which usage is not compatible with fh_model(). 
This PR restrains ADNLPModels versions to "0.3, 0.4, 0.7" in deps. 