### PR TITLE
cirrus: update and simplify workflow

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,21 +2,10 @@ task:
   matrix:
     - name: FreeBSD
       freebsd_instance:
-        image_family: freebsd-13-3
+        image_family: freebsd-14-2
       env:
         matrix:
-          - JULIA_VERSION: 1.6
           - JULIA_VERSION: 1
-    - name: musl Linux
-      container:
-        image: alpine:3.14
-      env:
-        - JULIA_VERSION: 1
-    - name: MacOS M1
-      macos_instance:
-        image: ghcr.io/cirruslabs/macos-monterey-base:latest
-      env:
-        - JULIA_VERSION: 1
   install_script: |
     URL="https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh"
     set -x


### PR DESCRIPTION
Restrict to julia 1 and FreeBSD.
Drop musl Linux and macOS M1.