### PR TITLE
Deprecate FirstOrderModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,14 @@
 name = "RegularizedProblems"
 uuid = "ea076b23-609f-44d2-bb12-a4ae45328278"
-authors = ["Dominique Orban <dominique.orban@gmail.com>, Robert Baraldi <robertjbaraldi@gmail.com"]
+authors = [
+  "Dominique Orban <dominique.orban@gmail.com>, Robert Baraldi <robertjbaraldi@gmail.com",
+]
 version = "0.1.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+ManualNLPModels = "30dfa513-9b2f-4fb3-9796-781eabac1617"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Noise = "81d43f40-5267-43b7-ae1c-8b967f377efa"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -15,6 +18,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 ADNLPModels = "^0.3, 0.4, 0.7"
 Distributions = "0.25"
+ManualNLPModels = "0.1"
 MLDatasets = "^0.7.4"
 NLPModels = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 Noise = "0.2"
@@ -31,4 +35,12 @@ ShiftedProximalOperators = "d4fd37fa-580c-4e43-9b30-361c21aae263"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADNLPModels", "DifferentialEquations", "MLDatasets", "ProximalOperators", "QuadraticModels", "ShiftedProximalOperators", "Test"]
+test = [
+  "ADNLPModels",
+  "DifferentialEquations",
+  "MLDatasets",
+  "ProximalOperators",
+  "QuadraticModels",
+  "ShiftedProximalOperators",
+  "Test",
+]

--- a/src/RegularizedProblems.jl
+++ b/src/RegularizedProblems.jl
@@ -2,7 +2,7 @@ module RegularizedProblems
 
 using LinearAlgebra, SparseArrays
 using Random, Requires
-using NLPModels
+using ManualNLPModels, NLPModels
 using Distributions, Noise
 
 include("utils.jl")

--- a/src/bpdn_model.jl
+++ b/src/bpdn_model.jl
@@ -52,7 +52,7 @@ The second form calls the first form with arguments
 
 ## Return Value
 
-An instance of a `FirstOrderModel` and of a `FirstOrderNLSModel` that represent the same
+An instance of an `NLPModel` and of a `FirstOrderNLSModel` that represent the same
 basis-pursuit denoise problem, and the exact solution x̄.
 
 If `bounds == true`, the positive part of x̄ is returned.

--- a/src/group_lasso_model.jl
+++ b/src/group_lasso_model.jl
@@ -61,7 +61,7 @@ groups divides evenly into the total number of elements.
 
 ## Return Value
 
-An instance of a `FirstOrderModel` that represents the group-lasso problem.
+An instance of an `NLPModel` that represents the group-lasso problem.
 An instance of a `FirstOrderNLSModel` that represents the group-lasso problem.
 Also returns true x, number of groups g, group-index denoting which groups are active, and a Matrix where rows are group indices of x.
 """

--- a/src/matrand_model.jl
+++ b/src/matrand_model.jl
@@ -68,7 +68,7 @@ retained by the operator P (default: 0.8)
 
 ## Return Value
 
-An instance of a `FirstOrderModel` and of a `FirstOrderNLSModel` that represent the same
+An instance of an `NLPModel` and of a `FirstOrderNLSModel` that represent the same
 matrix completion problem, and the exact solution.
 """
 function random_matrix_completion_model(;

--- a/src/nonlin_svm_model.jl
+++ b/src/nonlin_svm_model.jl
@@ -55,7 +55,7 @@ With the MNIST Dataset, the dimensions are:
 
 ## Return Value
 
-An instance of a `FirstOrderModel` that represents the complete SVM problem in NLP form, and
+An instance of an `NLPModel` that represents the complete SVM problem in NLP form, and
 an instance of `FirstOrderNLSModel` that represents the nonlinear least squares in nonlinear least squares form.
 """
 function svm_model(A, b)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,54 +1,8 @@
-export FirstOrderModel,
-  FirstOrderNLSModel, AbstractRegularizedNLPModel, RegularizedNLPModel, RegularizedNLSModel
+export FirstOrderNLSModel, AbstractRegularizedNLPModel, RegularizedNLPModel, RegularizedNLSModel
 
-"""
-    model = FirstOrderModel(f, ∇f!; name = "first-order model")
-
-A simple subtype of `AbstractNLPModel` to represent a smooth objective.
-
-## Arguments
-
-* `f :: F <: Function`: a function such that `f(x)` returns the objective value at `x`;
-* `∇f! :: G <: Function`: a function such that `∇f!(g, x)` stores the gradient of the
-  objective at `x` in `g`;
-* `x :: AbstractVector`: an initial guess.
-
-All keyword arguments are passed through to the `NLPModelMeta` constructor.
-"""
-mutable struct FirstOrderModel{T, S, F, G} <: AbstractNLPModel{T, S}
-  meta::NLPModelMeta{T, S}
-  counters::Counters
-
-  f::F
-  ∇f!::G
-
-  function FirstOrderModel{T, S, F, G}(
-    f::F,
-    ∇f!::G,
-    x::S;
-    kwargs...,
-  ) where {T, S, F <: Function, G <: Function}
-    nvar = length(x)
-    meta = NLPModelMeta(nvar, x0 = x; kwargs...)
-    return new{T, S, F, G}(meta, Counters(), f, ∇f!)
-  end
-end
-
-FirstOrderModel(f, ∇f!, x::S; kwargs...) where {S} =
-  FirstOrderModel{eltype(S), S, typeof(f), typeof(∇f!)}(f, ∇f!, x; kwargs...)
-
-function NLPModels.obj(nlp::FirstOrderModel, x::AbstractVector)
-  NLPModels.@lencheck nlp.meta.nvar x
-  increment!(nlp, :neval_obj)
-  return nlp.f(x)
-end
-
-function NLPModels.grad!(nlp::FirstOrderModel, x::AbstractVector, g::AbstractVector)
-  NLPModels.@lencheck nlp.meta.nvar x
-  increment!(nlp, :neval_grad)
-  nlp.∇f!(g, x)
-  return g
-end
+#! format: off
+@deprecate FirstOrderModel(f, ∇f!, x; kwargs...) NLPModel(x, f; grad = ∇f!, meta_args = Dict(kwargs...))
+#! format: on
 
 """
     model = FirstOrderNLSModel(r!, jv!, jtv!; name = "first-order NLS model")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 using LinearAlgebra, Test
-using ADNLPModels, DifferentialEquations, NLPModels, MLDatasets, QuadraticModels
+using ADNLPModels, DifferentialEquations, ManualNLPModels, MLDatasets, NLPModels, QuadraticModels
 using RegularizedProblems
 
 function test_well_defined(model, nls_model, sol)
-  @test typeof(model) <: FirstOrderModel
+  @test typeof(model) <: NLPModel
   @test typeof(sol) == typeof(model.meta.x0)
   @test typeof(nls_model) <: FirstOrderNLSModel
   @test model.meta.nvar == nls_model.meta.nvar
@@ -109,7 +109,7 @@ end
   @test_throws MethodError svm_train_model((1, 2, 3))
   @test_throws ErrorException svm_train_model((10, -1))
   nlp_train, nls_train, sol = svm_train_model()
-  @test typeof(nlp_train) <: FirstOrderModel
+  @test typeof(nlp_train) <: NLPModel
   @test typeof(nls_train) <: FirstOrderNLSModel
   @test typeof(sol) == Vector{Int64}
   test_objectives(nlp_train, nls_train)
@@ -127,7 +127,7 @@ end
   @test_throws MethodError svm_test_model((1, 2, 3))
   @test_throws ErrorException svm_test_model((10, -1))
   nlp_test, nls_test, sol = svm_test_model()
-  @test typeof(nlp_test) <: FirstOrderModel
+  @test typeof(nlp_test) <: NLPModel
   @test typeof(nls_test) <: FirstOrderNLSModel
   @test typeof(sol) == Vector{Int64}
   test_objectives(nlp_test, nls_test)


### PR DESCRIPTION
Instead, use equivalent functionality already implemented in ManualNLPModels.