### PR TITLE
deprecate FirstOrderNLSModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "ea076b23-609f-44d2-bb12-a4ae45328278"
 authors = [
   "Dominique Orban <dominique.orban@gmail.com>, Robert Baraldi <robertjbaraldi@gmail.com",
 ]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -18,7 +18,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 ADNLPModels = "^0.3, 0.4, 0.7"
 Distributions = "0.25"
-ManualNLPModels = "0.1"
+ManualNLPModels = "0.2"
 MLDatasets = "^0.7.4"
 NLPModels = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 Noise = "0.2"

--- a/src/bpdn_model.jl
+++ b/src/bpdn_model.jl
@@ -52,7 +52,7 @@ The second form calls the first form with arguments
 
 ## Return Value
 
-An instance of an `NLPModel` and of a `FirstOrderNLSModel` that represent the same
+An instance of an `NLPModel` and of an `NLSModel` that represent the same
 basis-pursuit denoise problem, and the exact solution x̄.
 
 If `bounds == true`, the positive part of x̄ is returned.

--- a/src/group_lasso_model.jl
+++ b/src/group_lasso_model.jl
@@ -62,7 +62,7 @@ groups divides evenly into the total number of elements.
 ## Return Value
 
 An instance of an `NLPModel` that represents the group-lasso problem.
-An instance of a `FirstOrderNLSModel` that represents the group-lasso problem.
+An instance of an `NLSModel` that represents the group-lasso problem.
 Also returns true x, number of groups g, group-index denoting which groups are active, and a Matrix where rows are group indices of x.
 """
 function group_lasso_model(args...; kwargs...)

--- a/src/matrand_model.jl
+++ b/src/matrand_model.jl
@@ -68,7 +68,7 @@ retained by the operator P (default: 0.8)
 
 ## Return Value
 
-An instance of an `NLPModel` and of a `FirstOrderNLSModel` that represent the same
+An instance of an `NLPModel` and of an `NLSModel` that represent the same
 matrix completion problem, and the exact solution.
 """
 function random_matrix_completion_model(;

--- a/src/nnmf.jl
+++ b/src/nnmf.jl
@@ -24,9 +24,9 @@ function nnmf_data(m::Int, n::Int, k::Int, T::DataType = Float64)
 end
 
 """
-    model, Av, selected = nnmf_model(m = 100, n = 50, k = 10, T = Float64)
+    model, nls_model, Av, selected = nnmf_model(m = 100, n = 50, k = 10, T = Float64)
 
-Return an instance of an `NLPModel` representing the non-negative matrix factorization
+Return an instance of an `NLPModel` and an `NLSModel` representing the non-negative matrix factorization
 objective
 
     f(W, H) = ½ ‖A - WH‖₂²,

--- a/src/nonlin_svm_model.jl
+++ b/src/nonlin_svm_model.jl
@@ -56,7 +56,7 @@ With the MNIST Dataset, the dimensions are:
 ## Return Value
 
 An instance of an `NLPModel` that represents the complete SVM problem in NLP form, and
-an instance of `FirstOrderNLSModel` that represents the nonlinear least squares in nonlinear least squares form.
+an instance of an `NLSModel` that represents the nonlinear least squares in nonlinear least-squares form.
 """
 function svm_model(A, b)
   Ahat = Diagonal(b) * A'

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,91 +1,10 @@
-export FirstOrderNLSModel, AbstractRegularizedNLPModel, RegularizedNLPModel, RegularizedNLSModel
+export AbstractRegularizedNLPModel, RegularizedNLPModel, RegularizedNLSModel
 
 #! format: off
 @deprecate FirstOrderModel(f, ∇f!, x; kwargs...) NLPModel(x, f; grad = ∇f!, meta_args = Dict(kwargs...))
+
+@deprecate FirstOrderNLSModel(r!, jv!, jtv!, nequ, x; kwargs...) NLSModel(x, r!, nequ; jprod = jv!, jtprod = jtv!, kwargs...)
 #! format: on
-
-"""
-    model = FirstOrderNLSModel(r!, jv!, jtv!; name = "first-order NLS model")
-
-A simple subtype of `AbstractNLSModel` to represent a nonlinear least-squares problem
-with a smooth residual.
-
-## Arguments
-
-* `r! :: R <: Function`: a function such that `r!(y, x)` stores the residual at `x` in `y`;
-* `jv! :: J <: Function`: a function such that `jv!(u, x, v)` stores the product between the residual Jacobian at `x` and the vector `v` in `u`;
-* `jtv! :: Jt <: Function`: a function such that `jtv!(u, x, v)` stores the product between the transpose of the residual Jacobian at `x` and the vector `v` in `u`;
-* `x :: AbstractVector`: an initial guess.
-
-All keyword arguments are passed through to the `NLPModelMeta` constructor.
-"""
-mutable struct FirstOrderNLSModel{T, S, R, J, Jt} <: AbstractNLSModel{T, S}
-  meta::NLPModelMeta{T, S}
-  nls_meta::NLSMeta{T, S}
-  counters::NLSCounters
-
-  resid!::R
-  jprod_resid!::J
-  jtprod_resid!::Jt
-
-  function FirstOrderNLSModel{T, S, R, J, Jt}(
-    r::R,
-    jv::J,
-    jtv::Jt,
-    nequ::Int,
-    x::S;
-    kwargs...,
-  ) where {T, S, R <: Function, J <: Function, Jt <: Function}
-    nvar = length(x)
-    meta = NLPModelMeta(nvar, x0 = x; kwargs...)
-    nls_meta = NLSMeta{T, S}(nequ, nvar, x0 = x)
-    return new{T, S, R, J, Jt}(meta, nls_meta, NLSCounters(), r, jv, jtv)
-  end
-end
-
-FirstOrderNLSModel(r, jv, jtv, nequ::Int, x::S; kwargs...) where {S} =
-  FirstOrderNLSModel{eltype(S), S, typeof(r), typeof(jv), typeof(jtv)}(
-    r,
-    jv,
-    jtv,
-    nequ,
-    x;
-    kwargs...,
-  )
-
-function NLPModels.residual!(nls::FirstOrderNLSModel, x::AbstractVector, Fx::AbstractVector)
-  NLPModels.@lencheck nls.meta.nvar x
-  NLPModels.@lencheck nls.nls_meta.nequ Fx
-  increment!(nls, :neval_residual)
-  nls.resid!(Fx, x)
-  Fx
-end
-
-function NLPModels.jprod_residual!(
-  nls::FirstOrderNLSModel,
-  x::AbstractVector,
-  v::AbstractVector,
-  Jv::AbstractVector,
-)
-  NLPModels.@lencheck nls.meta.nvar x v
-  NLPModels.@lencheck nls.nls_meta.nequ Jv
-  increment!(nls, :neval_jprod_residual)
-  nls.jprod_resid!(Jv, x, v)
-  Jv
-end
-
-function NLPModels.jtprod_residual!(
-  nls::FirstOrderNLSModel,
-  x::AbstractVector,
-  v::AbstractVector,
-  Jtv::AbstractVector,
-)
-  NLPModels.@lencheck nls.meta.nvar x Jtv
-  NLPModels.@lencheck nls.nls_meta.nequ v
-  increment!(nls, :neval_jtprod_residual)
-  nls.jtprod_resid!(Jtv, x, v)
-  Jtv
-end
 
 abstract type AbstractRegularizedNLPModel{T, S} <: AbstractNLPModel{T, S} end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using RegularizedProblems
 function test_well_defined(model, nls_model, sol)
   @test typeof(model) <: NLPModel
   @test typeof(sol) == typeof(model.meta.x0)
-  @test typeof(nls_model) <: FirstOrderNLSModel
+  @test typeof(nls_model) <: NLSModel
   @test model.meta.nvar == nls_model.meta.nvar
   @test all(model.meta.x0 .== nls_model.meta.x0)
 end
@@ -110,7 +110,7 @@ end
   @test_throws ErrorException svm_train_model((10, -1))
   nlp_train, nls_train, sol = svm_train_model()
   @test typeof(nlp_train) <: NLPModel
-  @test typeof(nls_train) <: FirstOrderNLSModel
+  @test typeof(nls_train) <: NLSModel
   @test typeof(sol) == Vector{Int64}
   test_objectives(nlp_train, nls_train)
 
@@ -128,7 +128,7 @@ end
   @test_throws ErrorException svm_test_model((10, -1))
   nlp_test, nls_test, sol = svm_test_model()
   @test typeof(nlp_test) <: NLPModel
-  @test typeof(nls_test) <: FirstOrderNLSModel
+  @test typeof(nls_test) <: NLSModel
   @test typeof(sol) == Vector{Int64}
   test_objectives(nlp_test, nls_test)
 


### PR DESCRIPTION
Instead, use NLSModel from ManualNLPModels.jl.