### PR TITLE
Add matrix_free parameter to make fh compatible with ADNLPModels

### DIFF
--- a/src/fh_model.jl
+++ b/src/fh_model.jl
@@ -87,7 +87,7 @@ of an `ADNLSModel` that represents the same problem, and the exact solution.
 function fh_model(; kwargs...)
   data, simulate, resid, misfit, x0 = FH_smooth_term()
   nequ = 202
-  ADNLPModels.ADNLPModel(misfit, ones(5); matrix_free = true, kwargs...),
-  ADNLPModels.ADNLSModel(resid, ones(5), nequ; matrix_free = true, kwargs...),
+  ADNLPModels.ADNLPModel(misfit, ones(5); kwargs...),
+  ADNLPModels.ADNLSModel(resid, ones(5), nequ; kwargs...),
   x0
 end


### PR DESCRIPTION
@dpo It seems there is an issue with the newer versions of ADNLPModels. Following @nathanemac’s suggestion, I added a matrix_free parameter to ensure compatibility with the latest version of ADNLPModels.