### PR TITLE
Fix CommentBreakage workflow

### DIFF
--- a/.github/workflows/CommentBreakage.yml
+++ b/.github/workflows/CommentBreakage.yml
@@ -28,13 +28,11 @@ jobs:
       - name: Generate summary
         run: |
           cd breakage
-
           echo "| Package name | latest | stable |" > summary.md
           echo "|--|--|--|" >> summary.md
           count=0
-          for dir in breakage-*
+          for file in breakage-*
           do
-            file=$dir/$(ls "$dir")
             if [ $count == "0" ]; then
               name=$(echo $file | cut -f2 -d-)
               echo -n "| $name | "


### PR DESCRIPTION
#100
See this failed run: https://github.com/JuliaSmoothOptimizers/RegularizedProblems.jl/actions/runs/23072486210
I retested on a private repo (but it's quite hard to copy the Breakage workflow correctly), the workflow should (hopefuly) work now.

Sorry for polluting the GitHub history...